### PR TITLE
Updated dockerfile to support mosquitto bridge with tls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ### Latest Approved Mosquitto Instance
 
 # ---- Mosquitto Instance ----
-FROM eclipse-mosquitto:latest AS mosquitto
+FROM eclipse-mosquitto:2.0.18-openssl AS mosquitto
 
 # RUN --mount=type=secret,id=mtc_password mosquitto_passwd -c -b /mosquitto/data/passwd mtconnect $(cat /run/secrets/mtc_password)
 RUN --mount=type=secret,id=MTC_PASSWD,target=/run/secrets/MTC_PASSWD \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ### Latest Approved Mosquitto Instance
 
 # ---- Mosquitto Instance ----
-FROM eclipse-mosquitto:2.0.18-openssl AS mosquitto
+FROM eclipse-mosquitto:openssl AS mosquitto
 
 # RUN --mount=type=secret,id=mtc_password mosquitto_passwd -c -b /mosquitto/data/passwd mtconnect $(cat /run/secrets/mtc_password)
 RUN --mount=type=secret,id=MTC_PASSWD,target=/run/secrets/MTC_PASSWD \


### PR DESCRIPTION
Jira ID - EP6US9TS3

- Replaced the base image to `eclipe-mosquitto:2.0.18-openssl` in Dockerfile to support mosquitto bridge with tls